### PR TITLE
어드민 로그인 체크 로직 수정

### DIFF
--- a/src/components/common/molecules/ProfileBoard/index.tsx
+++ b/src/components/common/molecules/ProfileBoard/index.tsx
@@ -24,7 +24,6 @@ const ProfileBoard = () => {
         const newProfile = user?.data
         localStorage.setItem('cachedProfile', JSON.stringify(newProfile))
         setProfile(newProfile)
-        console.log('22')
       } catch (error) {
         console.error('Error fetching profile:', error)
       }
@@ -32,8 +31,8 @@ const ProfileBoard = () => {
 
     if (!profile) {
       fetchProfile()
-    }
-    if (profile.role === 'ROLE_ADMIN' && role !== 'admin') setRole('admin')
+    } else if (profile.role === 'ROLE_ADMIN' && role !== 'admin')
+      setRole('admin')
   }, [profile, refetch])
 
   return (


### PR DESCRIPTION
### 개요
어드민 로그인을 위한 체크 로직이 local storage에 정보를 넣기전에 role을 불러와 문제가 생겼었습니다.
### 작업사항
else if 로 바꾸어 profile이 없으면 작동되지 않게 해놓았습니다.
