### PR TITLE
태그 삭제 및 로그아웃에 프로필 정보 삭제 추가

### DIFF
--- a/src/components/Rental/atoms/RentalItem/index.tsx
+++ b/src/components/Rental/atoms/RentalItem/index.tsx
@@ -5,15 +5,6 @@ import Link from 'next/link'
 import { RentalItemPropsType } from 'types/components/Rental/RentalType'
 import { Palette } from 'style/global'
 
-interface getNameFromValuePropstype {
-  list: {
-    name: string
-    value: string
-    color: string
-  }[]
-  valueToFind: string
-}
-
 export default function RentalItem({
   thumbnail,
   title,
@@ -25,26 +16,9 @@ export default function RentalItem({
   id,
   periodColor,
 }: RentalItemPropsType) {
-  const Loading = {
-    name: '로딩중',
-    value: 'Loading',
-    color: Palette.NATURAL_N4,
-  }
   const replaceDate = (date: string): string => {
     return date.split('T')[0].replace(/-/g, '.')
   }
-  const getNameFromValue = ({
-    list,
-    valueToFind,
-  }: getNameFromValuePropstype) => {
-    const item = list.find((item) => item.value === valueToFind)
-    return item ? item : Loading
-  }
-
-  const equipmentStatusName = getNameFromValue({
-    list: FilterListData.equipmentStatusList,
-    valueToFind: tag,
-  })
 
   return (
     <Link href={`/home/${id}`}>
@@ -54,7 +28,6 @@ export default function RentalItem({
             <img src={thumbnail} />
           </S.thumbnailWrapper>
           <S.Title>{title}</S.Title>
-          {/* <Tag data={equipmentStatusName} role="admin" /> */}
         </S.TitleWrapper>
         <S.informationWrapper>
           <S.studentWrapper>대여 학생: {student}</S.studentWrapper>

--- a/src/components/Rental/atoms/RentalItem/index.tsx
+++ b/src/components/Rental/atoms/RentalItem/index.tsx
@@ -54,7 +54,7 @@ export default function RentalItem({
             <img src={thumbnail} />
           </S.thumbnailWrapper>
           <S.Title>{title}</S.Title>
-          <Tag data={equipmentStatusName} role="admin" />
+          {/* <Tag data={equipmentStatusName} role="admin" /> */}
         </S.TitleWrapper>
         <S.informationWrapper>
           <S.studentWrapper>대여 학생: {student}</S.studentWrapper>

--- a/src/utils/libs/logout.ts
+++ b/src/utils/libs/logout.ts
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify'
 import toastOption from 'utils/libs/toastOption'
 export const logout = () => {
   removeToken()
+  localStorage.removeItem('cachedProfile')
   mutate(() => true, undefined, { revalidate: false })
   toast.success('로그아웃되었습니다.', toastOption)
 }


### PR DESCRIPTION
## 개요
연체, 대여중인 리스트에 equipment  status 태그가 불필요해 보임
로그아웃에 cachedProfile삭제가 없어 프로필이 유지되어 어드민이 유지됨
## 작업사항
+ 어드민의 연체 대여중 리스트의 equipment status tag 삭제
+ 로그아웃에 cachedProfile삭제 추가

