### PR TITLE
Gauth URL을 env로 변경 

### DIFF
--- a/src/utils/libs/gauthUrl.ts
+++ b/src/utils/libs/gauthUrl.ts
@@ -1,1 +1,1 @@
-export const gauthUrl = `https://gauth.co.kr/login?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}`
+export const gauthUrl = `${process.env.NEXT_PUBLIC_GAUTH_URL}/login?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}`


### PR DESCRIPTION
### 개요
Gauth의 url이 다른 url로 변경되었습니다.
### 작업사항
Gauth의 url의 변동사항이 추후에 더 생길 가능성이 있다고 판단해 env로 변경하였습니다.