### PR TITLE
검색 페이지 디바운싱 적용

### DIFF
--- a/src/components/common/molecules/SearchField/index.tsx
+++ b/src/components/common/molecules/SearchField/index.tsx
@@ -6,26 +6,39 @@ import { getData } from 'utils/apis/data'
 import { EquipmentController } from 'utils/libs/requestUrls'
 import * as S from './style'
 
+
 const SearchField = () => {
   const role = useRecoilValue(roleType)
+  const [list, setList] = useRecoilState(searchState)
   const [inputValue, setInputValue] = useState('')
   const url = EquipmentController.serachEquipment()
+  const DEBOUNCE_TIME = 200;
+
   const { data, refetch } = useQuery(
-    ['search', url, { name: inputValue }],
+    ['search', url],
     () => {
       return getData(url, { name: inputValue })
     },
     {
-      enabled: !!url,
       refetchOnWindowFocus: false,
     },
   )
-  const [list, setList] = useRecoilState(searchState)
+
+ 
   useEffect(() => {
-    refetch()
-    if (data) setList(data?.data?.equipmentList)
-  }, [inputValue, refetch, data, setList])
-  const handleInputChange = (e: any) => {
+    let delayTimer: NodeJS.Timeout
+
+    const delayedFetch = (): void => {
+      clearTimeout(delayTimer)
+      delayTimer = setTimeout(() => {
+        refetch()
+      }, DEBOUNCE_TIME)
+    }
+    delayedFetch()
+
+    return () => clearTimeout(delayTimer)
+  }, [inputValue,refetch])
+  const handleInputChange = (e:React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value)
   }
   return (

--- a/src/components/common/molecules/SearchField/index.tsx
+++ b/src/components/common/molecules/SearchField/index.tsx
@@ -12,7 +12,6 @@ const SearchField = () => {
   const [list, setList] = useRecoilState(searchState)
   const [inputValue, setInputValue] = useState('')
   const url = EquipmentController.serachEquipment()
-  const DEBOUNCE_TIME = 200;
 
   const { data, refetch } = useQuery(
     ['search', url],
@@ -32,7 +31,8 @@ const SearchField = () => {
       clearTimeout(delayTimer)
       delayTimer = setTimeout(() => {
         refetch()
-      }, DEBOUNCE_TIME)
+        if (data) setList(data?.data?.equipmentList)
+      }, 200)
     }
     delayedFetch()
 


### PR DESCRIPTION
## 개요
검색 페이지의 api가 글자가 onChange 될때마다 요청을 보내 잦은 렌더링이 발생하고 있었습니다.

## 작업사항
Debouncing를 적용해 사용자가 입력을 끝냈을 때만 요청을 보낼 수 있게 변경하였습니다.
