### PR TITLE
메인페이지 기자재 리스트 리렌더링 방지

### DIFF
--- a/src/asset/data/FilterListData.ts
+++ b/src/asset/data/FilterListData.ts
@@ -1,21 +1,20 @@
 export interface FilterListDataType {
-  equipmentStatusList: EquipmentStatus[];
-  equipmentType: EquipmentType[];
+  equipmentStatusList: EquipmentStatus[]
+  equipmentType: EquipmentType[]
 }
 
-interface EquipmentStatus {
-  name: string;
-  value: string;
-  color: string;
+export interface EquipmentStatus {
+  name: string
+  value: string
+  color: string
 }
 
-interface EquipmentType {
-  name: string;
-  value: string;
+export interface EquipmentType {
+  name: string
+  value: string
 }
 
-
-export const FilterListData : FilterListDataType = {
+export const FilterListData: FilterListDataType = {
   equipmentStatusList: [
     {
       name: '전체',
@@ -78,3 +77,5 @@ export const FilterListData : FilterListDataType = {
     },
   ],
 }
+
+export default FilterListData

--- a/src/asset/data/FilterListData.ts
+++ b/src/asset/data/FilterListData.ts
@@ -1,4 +1,21 @@
-export const FilterListData = {
+export interface FilterListDataType {
+  equipmentStatusList: EquipmentStatus[];
+  equipmentType: EquipmentType[];
+}
+
+interface EquipmentStatus {
+  name: string;
+  value: string;
+  color: string;
+}
+
+interface EquipmentType {
+  name: string;
+  value: string;
+}
+
+
+export const FilterListData : FilterListDataType = {
   equipmentStatusList: [
     {
       name: '전체',

--- a/src/components/common/atoms/RentalItem/index.tsx
+++ b/src/components/common/atoms/RentalItem/index.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { FilterListData } from 'asset/data/FilterListData'
+import {
+  FilterListData,
+  EquipmentStatus,
+  EquipmentType,
+} from 'asset/data/FilterListData'
 import Tag from 'components/common/atoms/Tag'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -8,13 +12,9 @@ import { useRecoilState } from 'recoil'
 import { DeleteChoice } from 'recoilAtoms'
 import { RentalItemPropsType } from 'types/components/Home/RentalTypes'
 import * as S from './style'
-import React from 'react'
-interface getNameFromValuePropstype {
-  list: {
-    name: string
-    value: string
-    color?: string
-  }[]
+import React, { useCallback } from 'react'
+interface getNameFromValueParameterType {
+  list: EquipmentStatus[] | EquipmentType[]
   valueToFind: string
 }
 
@@ -27,28 +27,34 @@ function RentalItem({
   equipmentStatus,
   role,
 }: RentalItemPropsType) {
-  const Loading = {
-    name: '로딩중',
-    value: 'Loading',
-  }
   const [deleteIds, setDeleteIds] = useRecoilState(DeleteChoice)
+  const router = usePathname()
+
   const getNameFromValue = ({
     list,
     valueToFind,
-  }: getNameFromValuePropstype) => {
+  }: getNameFromValueParameterType) => {
     const item = list.find((item) => item.value === valueToFind)
-    return item ? item : Loading
+    return item
+      ? item
+      : {
+          name: '로딩중',
+          value: 'Loading',
+        }
   }
+
   const equipmentTypeName = getNameFromValue({
     list: FilterListData.equipmentType,
     valueToFind: equipmentType,
   })
+
   const equipmentStatusName = getNameFromValue({
     list: FilterListData.equipmentStatusList,
     valueToFind: equipmentStatus,
   })
-  const router = usePathname()
+
   const isProductManagementPage = router === '/productmanagement'
+
   const handleCheckboxChange = () => {
     if (isProductManagementPage) {
       if (deleteIds.includes(id)) {
@@ -58,6 +64,7 @@ function RentalItem({
       }
     }
   }
+
   const LinkBox = () => {
     if (isProductManagementPage) {
       return <Layer />
@@ -101,4 +108,4 @@ function RentalItem({
   return <LinkBox />
 }
 
-export default React.memo(RentalItem)
+export default RentalItem

--- a/src/components/common/atoms/RentalItem/index.tsx
+++ b/src/components/common/atoms/RentalItem/index.tsx
@@ -12,7 +12,7 @@ import { useRecoilState } from 'recoil'
 import { DeleteChoice } from 'recoilAtoms'
 import { RentalItemPropsType } from 'types/components/Home/RentalTypes'
 import * as S from './style'
-import React, { useCallback } from 'react'
+import React from 'react'
 interface getNameFromValueParameterType {
   list: EquipmentStatus[] | EquipmentType[]
   valueToFind: string
@@ -65,19 +65,7 @@ function RentalItem({
     }
   }
 
-  const LinkBox = () => {
-    if (isProductManagementPage) {
-      return <Layer />
-    } else {
-      return (
-        <Link href={`/home/${id}`}>
-          <Layer />
-        </Link>
-      )
-    }
-  }
-
-  const Layer = () => {
+  const RentalComponent = () => {
     return (
       <S.Layer>
         <S.CheckWrapper>
@@ -105,7 +93,20 @@ function RentalItem({
       </S.Layer>
     )
   }
-  return <LinkBox />
+
+  const ConditionalLinkWrapper = () => {
+    if (isProductManagementPage) {
+      return <RentalComponent />
+    } else {
+      return (
+        <Link href={`/home/${id}`}>
+          <RentalComponent />
+        </Link>
+      )
+    }
+  }
+
+  return <ConditionalLinkWrapper />
 }
 
 export default RentalItem

--- a/src/components/common/atoms/RentalItem/index.tsx
+++ b/src/components/common/atoms/RentalItem/index.tsx
@@ -31,7 +31,6 @@ function RentalItem({
     name: '로딩중',
     value: 'Loading',
   }
-  console.log("리렌더링")
   const [deleteIds, setDeleteIds] = useRecoilState(DeleteChoice)
   const getNameFromValue = ({
     list,

--- a/src/components/common/atoms/RentalItem/index.tsx
+++ b/src/components/common/atoms/RentalItem/index.tsx
@@ -8,7 +8,7 @@ import { useRecoilState } from 'recoil'
 import { DeleteChoice } from 'recoilAtoms'
 import { RentalItemPropsType } from 'types/components/Home/RentalTypes'
 import * as S from './style'
-
+import React from 'react'
 interface getNameFromValuePropstype {
   list: {
     name: string
@@ -31,6 +31,7 @@ function RentalItem({
     name: '로딩중',
     value: 'Loading',
   }
+  console.log("리렌더링")
   const [deleteIds, setDeleteIds] = useRecoilState(DeleteChoice)
   const getNameFromValue = ({
     list,
@@ -101,4 +102,4 @@ function RentalItem({
   return <LinkBox />
 }
 
-export default RentalItem
+export default React.memo(RentalItem)

--- a/src/components/common/atoms/RentalItem/index.tsx
+++ b/src/components/common/atoms/RentalItem/index.tsx
@@ -68,7 +68,7 @@ function RentalItem({
   const LinkBox = () => {
     if (isProductManagementPage) {
       return <Layer />
-    } else if (!isProductManagementPage) {
+    } else {
       return (
         <Link href={`/home/${id}`}>
           <Layer />
@@ -79,7 +79,7 @@ function RentalItem({
 
   const Layer = () => {
     return (
-      <S.Layer onClick={() => {}}>
+      <S.Layer>
         <S.CheckWrapper>
           {isProductManagementPage && (
             <S.Check


### PR DESCRIPTION
## 개요
메인페이지의 기자재 리스트를 전체 리스트로 가져오다보니 리스트가 많아지면 필터를 통해 이동시 불필요한 리스트 요소의 리렌더링이 이루어졌습니다.
## 작업사항
React.mome()를 통해 변하지 않는 기자재일경우 리렌더링을 방지했습니다. <br/><br/>
```md
초기 렌더링 리스트 수(전체) : 28개 
모니터 필터 변경시 리스트 수 : 15개
```
### 변경 전
<img width="634" alt="스크린샷 2024-04-21 00 18 21" src="https://github.com/Team-Ampersand/GKR-Frontend/assets/105274015/d7ed5dac-3ccc-4193-b4c0-4921199b8649">

### 변경 후
<img width="629" alt="스크린샷 2024-04-21 00 16 34" src="https://github.com/Team-Ampersand/GKR-Frontend/assets/105274015/a69b6868-c913-4d55-a0dd-552831519afc">

## 변경로직
+ rentalItem에 react.memo()적용
